### PR TITLE
Work Day Entity Management

### DIFF
--- a/rest-client/requests.http
+++ b/rest-client/requests.http
@@ -339,7 +339,7 @@ Authorization: Bearer {{JwtToken}}
 
 ### Preview motoboy payout
 # @name previewPayout
-GET {{baseUrl}}/payout/preview?name=Fernando&from=17/10/2025
+GET {{baseUrl}}/payout/preview?name=Fernando
 Authorization: Bearer {{JwtToken}}
 
 ### Create motoboy payout

--- a/rest-client/requests.http
+++ b/rest-client/requests.http
@@ -23,13 +23,13 @@ Authorization: Bearer {{JwtToken}}
 Content-Type: application/json
 
 {
-  "name": "LOCAL Comercio de bebidas - PJ",
-  "businessName": "Deck Lagoinha",
-  "cnpj": "XXX.XXX.XXX/0001-XX",
-  "cpf": "XXX.XXX.XXX-XX",
-  "phone": "48999887755",
-  "secondPhone": "48999887766",
-  "email": "deck@email.com",
+  "name": "Aonde Comercio de bebidas - PJ",
+  "businessName": "Deck Central",
+  "cnpj": "YYY.YYY.YYY/0001-YY",
+  "cpf": "YYY.YYY.YYY-YY",
+  "phone": "48999887766",
+  "secondPhone": "48999887777",
+  "email": "deckcentral@email.com",
   "address": {
     "street": "Rua Dois",
     "neighborhood": "Valência"
@@ -60,18 +60,18 @@ Authorization: Bearer {{JwtToken}}
 Content-Type: application/json
 
 {
-  "name": "Sérgio",
-  "phone": "48999558878",
-  "email": "sergio@email.com",
+  "name": "Fernando",
+  "phone": "48999558880",
+  "email": "fernando@email.com",
   "role": "motoboy",
   "password": "123456",
   "workTime": {
     "shift": "personalizado",
-    "initHour": 18,
+    "initHour": 23,
     "endHour": 4
   },
-  "motorcycle": "Yamaha, 2017, 300, Vermelha",
-  "daily": 30
+  "motorcycle": "Yamaha, 2017, 300, Preta",
+  "daily": 15
 }
 
 # {
@@ -339,7 +339,7 @@ Authorization: Bearer {{JwtToken}}
 
 ### Preview motoboy payout
 # @name previewPayout
-GET {{baseUrl}}/payout/preview?name=Guilherme
+GET {{baseUrl}}/payout/preview?name=Fernando&from=17/10/2025
 Authorization: Bearer {{JwtToken}}
 
 ### Create motoboy payout

--- a/rest-client/requests.http
+++ b/rest-client/requests.http
@@ -14,6 +14,38 @@ Content-Type: application/json
   "password": "123456"
 }
 
+################### PLACE ###################
+
+### Create place
+# @name createUser
+POST {{baseUrl}}/place/me
+Authorization: Bearer {{JwtToken}}
+Content-Type: application/json
+
+{
+  "name": "LOCAL Comercio de bebidas - PJ",
+  "businessName": "Deck Lagoinha",
+  "cnpj": "XXX.XXX.XXX/0001-XX",
+  "cpf": "XXX.XXX.XXX-XX",
+  "phone": "48999887755",
+  "secondPhone": "48999887766",
+  "email": "deck@email.com",
+  "address": {
+    "street": "Rua Dois",
+    "neighborhood": "Valência"
+  },
+  "postalBox": {
+    "street": "Rua Quinze",
+    "neighborhood": "Docas"
+  },
+  "workTime": {
+    "shift": "personalizado",
+    "initHour": 18,
+    "endHour": 4,
+    "isDefault": true 
+  }
+}
+
 ################### USER ###################
 
 ### Create user

--- a/rest-client/requests.http
+++ b/rest-client/requests.http
@@ -46,6 +46,11 @@ Content-Type: application/json
   }
 }
 
+### Find place
+# @name findOnePlace
+GET {{baseUrl}}/place/0471bb6a-88cd-414a-83bb-7aca9edabfaf
+Authorization: Bearer {{JwtToken}}
+
 ################### USER ###################
 
 ### Create user

--- a/rest-client/requests.http
+++ b/rest-client/requests.http
@@ -302,7 +302,7 @@ Authorization: Bearer {{JwtToken}}
 
 ### Preview motoboy payout
 # @name previewPayout
-GET {{baseUrl}}/payout/preview?name=Sérgio&from=22-10-2025
+GET {{baseUrl}}/payout/preview?name=Guilherme
 Authorization: Bearer {{JwtToken}}
 
 ### Create motoboy payout

--- a/rest-client/requests.http
+++ b/rest-client/requests.http
@@ -48,8 +48,21 @@ Content-Type: application/json
 
 ### Find place
 # @name findOnePlace
-GET {{baseUrl}}/place/0471bb6a-88cd-414a-83bb-7aca9edabfaf
+GET {{baseUrl}}/place/5c52c543-9230-481e-8e70-f38c0f332644
 Authorization: Bearer {{JwtToken}}
+
+### Add work time
+# @name findOnePlace
+POST {{baseUrl}}/place/5c52c543-9230-481e-8e70-f38c0f332644/work-time
+Authorization: Bearer {{JwtToken}}
+Content-Type: application/json
+
+{
+  "shift": "manhã",
+  "initHour": 9,
+  "endHour": 13,
+  "isDefault": false
+}
 
 ################### USER ###################
 

--- a/src/delivery/pipes/parse-br-work-date.pipe.ts
+++ b/src/delivery/pipes/parse-br-work-date.pipe.ts
@@ -1,0 +1,36 @@
+import { ArgumentMetadata, Injectable, PipeTransform } from '@nestjs/common';
+import { parseBrDate } from 'src/common/utils/parse-br-date';
+import { PlaceService } from 'src/place/place.service';
+
+@Injectable()
+export class ParseBrWorkDatePipe implements PipeTransform {
+  private readonly paramTypes = ['body', 'query'];
+
+  constructor(private readonly placeService: PlaceService) {}
+
+  async transform(value: string, { type, data }: ArgumentMetadata) {
+    const place = await this.placeService.findOneBy({ cpf: 'XXX.XXX.XXX-XX' });
+
+    if (!place || !value || !this.paramTypes.includes(type)) {
+      return undefined;
+    }
+
+    const { workTimes } = place;
+    const { initHour, endHour } = workTimes.filter(item =>
+      Boolean(item.isDefault),
+    )[0];
+
+    const parsedValue = value.split('-').join('/');
+
+    if (data === 'from') {
+      console.log(parseBrDate(parsedValue, initHour));
+      return parseBrDate(parsedValue, initHour);
+    }
+
+    if (data === 'to') {
+      return parseBrDate(parsedValue, endHour);
+    }
+
+    return undefined;
+  }
+}

--- a/src/delivery/pipes/parse-br-work-date.pipe.ts
+++ b/src/delivery/pipes/parse-br-work-date.pipe.ts
@@ -9,7 +9,10 @@ export class ParseBrWorkDatePipe implements PipeTransform {
   constructor(private readonly placeService: PlaceService) {}
 
   async transform(value: string, { type, data }: ArgumentMetadata) {
-    const place = await this.placeService.findOneBy({ cpf: 'XXX.XXX.XXX-XX' });
+    const code = process.env.DEFAULT_PLACE_CODE || undefined;
+    const place = await this.placeService.findOneBy({
+      code,
+    });
 
     if (!place || !value || !this.paramTypes.includes(type)) {
       return undefined;
@@ -23,7 +26,6 @@ export class ParseBrWorkDatePipe implements PipeTransform {
     const parsedValue = value.split('-').join('/');
 
     if (data === 'from') {
-      console.log(parseBrDate(parsedValue, initHour));
       return parseBrDate(parsedValue, initHour);
     }
 

--- a/src/delivery/pipes/parse-br-work-date.pipe.ts
+++ b/src/delivery/pipes/parse-br-work-date.pipe.ts
@@ -10,6 +10,13 @@ export class ParseBrWorkDatePipe implements PipeTransform {
 
   async transform(value: string, { type, data }: ArgumentMetadata) {
     const code = process.env.DEFAULT_PLACE_CODE || undefined;
+
+    // se as Places forem deletadas:
+    // criar uma Place sem o código
+    // verificar se `code === undefined`
+    // retorna place === null || Place
+    // ou seja, será que ele pega a primeira que existe?
+    // Se pegar, pode haver algum bug escondido aqui
     const place = await this.placeService.findOneBy({
       code,
     });
@@ -18,19 +25,19 @@ export class ParseBrWorkDatePipe implements PipeTransform {
       return undefined;
     }
 
-    const { workTimes } = place;
-    const { initHour, endHour } = workTimes.filter(item =>
-      Boolean(item.isDefault),
-    )[0];
+    const workTimes = place.workTimes.filter(item => item.isDefault === true);
 
-    const parsedValue = value.split('-').join('/');
+    if (workTimes.length > 0) {
+      const { initHour, endHour } = workTimes[0];
+      const parsedValue = value.split('-').join('/');
 
-    if (data === 'from') {
-      return parseBrDate(parsedValue, initHour);
-    }
+      if (data === 'from') {
+        return parseBrDate(parsedValue, initHour);
+      }
 
-    if (data === 'to') {
-      return parseBrDate(parsedValue, endHour);
+      if (data === 'to') {
+        return parseBrDate(parsedValue, endHour);
+      }
     }
 
     return undefined;

--- a/src/payout/payout.controller.ts
+++ b/src/payout/payout.controller.ts
@@ -21,6 +21,7 @@ import { Role } from 'src/common/role/roles.enum';
 import { WeekDay } from 'src/common/enums/weekDays.enum';
 import { AuthenticatedRequest } from 'src/auth/types/authenticated-request.type';
 import { ParseBrPhonePipe } from 'src/user/pipes/format-br-phone.pipe';
+import { ParseBrWorkDatePipe } from 'src/delivery/pipes/parse-br-work-date.pipe';
 
 @Roles(Role.Admin, Role.Operator, Role.Motoboy)
 @Controller('payout')
@@ -29,8 +30,8 @@ export class PayoutController {
 
   @Get('preview')
   async preview(
-    @Query('from', new ParseBrDatePipe(START_TIME)) from: Date,
-    @Query('to', new ParseBrDatePipe(END_TIME)) to: Date,
+    @Query('from', ParseBrWorkDatePipe) from: Date,
+    @Query('to', ParseBrWorkDatePipe) to: Date,
     @Query('name') name: string,
     @Query('phone', ParseBrPhonePipe) phone: string,
     @Query('id', new ParseUUIDPipe({ optional: true })) id: string,

--- a/src/payout/payout.module.ts
+++ b/src/payout/payout.module.ts
@@ -6,6 +6,7 @@ import { Payout } from './entities/payout.entity';
 import { DeliveryModule } from 'src/delivery/delivery.module';
 import { UserModule } from 'src/user/user.module';
 import { VoucherModule } from 'src/voucher/voucher.module';
+import { PlaceModule } from 'src/place/place.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { VoucherModule } from 'src/voucher/voucher.module';
     DeliveryModule,
     UserModule,
     VoucherModule,
+    PlaceModule,
   ],
   controllers: [PayoutController],
   providers: [PayoutService],

--- a/src/payout/payout.service.ts
+++ b/src/payout/payout.service.ts
@@ -14,7 +14,6 @@ import {
   CURRENT_SHORT_DATE,
   END_TIME,
   IS_ANOTHER_DAY,
-  START_TIME,
 } from 'src/common/operation-time';
 import { parseBrDate } from 'src/common/utils/parse-br-date';
 import { UserService } from 'src/user/user.service';
@@ -25,6 +24,7 @@ import { WeekDay, weekDays } from 'src/common/enums/weekDays.enum';
 import voucherRelations from '../voucher/data/relations/voucher';
 import { generateRelativeDate } from 'src/common/utils/generate-date';
 import { generateBadRequestException } from 'src/common/generate-exception';
+import { PlaceService } from 'src/place/place.service';
 
 @Injectable()
 export class PayoutService {
@@ -36,6 +36,7 @@ export class PayoutService {
     private readonly deliveryService: DeliveryService,
     private readonly userService: UserService,
     private readonly voucherService: VoucherService,
+    private readonly placeService: PlaceService,
   ) {}
 
   async preview(from: Date, to: Date, motoboyData: Partial<DeliveryMan>) {
@@ -44,17 +45,27 @@ export class PayoutService {
     }
 
     const motoboy = await this.userService.findOneMotoboyByOrFail(motoboyData);
+    const place = await this.placeService.findOneBy({
+      code: process.env.DEFAULT_PLACE_CODE,
+    });
 
+    if (!place) {
+      throw new NotFoundException(
+        'Nenhum estabelecimento definido como padrão',
+      );
+    }
+
+    const workTime = place.workTimes.filter(item => Boolean(item.isDefault))[0];
     const dateObject = {
-      initDate: from || parseBrDate(CURRENT_SHORT_DATE, START_TIME),
-      endDate: to || parseBrDate(CURRENT_SHORT_DATE, END_TIME),
+      initDate: from || parseBrDate(CURRENT_SHORT_DATE, workTime.initHour),
+      endDate: to || parseBrDate(CURRENT_SHORT_DATE, workTime.endHour),
     };
 
-    if (END_TIME < START_TIME) {
+    if (workTime.endHour < workTime.initHour) {
       dateObject.endDate = generateRelativeDate(
         'tomorrow',
         dateObject.initDate,
-        END_TIME,
+        workTime.endHour,
       );
     }
 

--- a/src/payout/payout.service.ts
+++ b/src/payout/payout.service.ts
@@ -55,17 +55,20 @@ export class PayoutService {
       );
     }
 
-    const workTime = place.workTimes.filter(item => Boolean(item.isDefault))[0];
+    const workTimes = place.workTimes.filter(item => item.isDefault === true);
+    const initHour = workTimes.length > 0 ? workTimes[0].initHour : 7;
+    const endHour = workTimes.length > 0 ? workTimes[0].endHour : 17;
+
     const dateObject = {
-      initDate: from || parseBrDate(CURRENT_SHORT_DATE, workTime.initHour),
-      endDate: to || parseBrDate(CURRENT_SHORT_DATE, workTime.endHour),
+      initDate: from || parseBrDate(CURRENT_SHORT_DATE, initHour),
+      endDate: to || parseBrDate(CURRENT_SHORT_DATE, endHour),
     };
 
-    if (workTime.endHour < workTime.initHour) {
+    if (endHour < initHour) {
       dateObject.endDate = generateRelativeDate(
         'tomorrow',
         dateObject.initDate,
-        workTime.endHour,
+        endHour,
       );
     }
 

--- a/src/payout/payout.service.ts
+++ b/src/payout/payout.service.ts
@@ -63,8 +63,12 @@ export class PayoutService {
       const initShortDate = dateObject.initDate.toLocaleString('BR', {
         dateStyle: 'short',
       });
+      const endShortDate = dateObject.endDate.toLocaleString('BR', {
+        dateStyle: 'short',
+      });
 
       dateObject.initDate = parseBrDate(initShortDate, initHour);
+      dateObject.endDate = parseBrDate(endShortDate, endHour);
 
       if (endHour < initHour) {
         dateObject.endDate = generateRelativeDate(

--- a/src/payout/payout.service.ts
+++ b/src/payout/payout.service.ts
@@ -142,10 +142,7 @@ export class PayoutService {
       return payout;
     }
 
-    const { workDay } = lastPayouts[0];
-    const lastPayout = await this.findOneByWorkDayAndMotoboy(workDay, {
-      id: motoboy.id,
-    });
+    const lastPayout = lastPayouts[0];
 
     if (lastPayout && lastPayout.total < 0) {
       payout.total = setDecimalPlaces(payout.total + lastPayout.total, 2);

--- a/src/place/dto/place/create-place.dto.ts
+++ b/src/place/dto/place/create-place.dto.ts
@@ -6,7 +6,6 @@ import {
   IsNotEmptyObject,
   IsPhoneNumber,
   IsString,
-  IsUUID,
 } from 'class-validator';
 
 export class CreatePlaceDto {
@@ -35,8 +34,8 @@ export class CreatePlaceDto {
   @IsEmail({}, { message: 'Email inválido' })
   email: string;
 
-  @IsUUID('4', { message: 'Formato inválido' })
-  ownerId: string;
+  // @IsUUID('4', { message: 'Formato inválido' })
+  // ownerId: string;
 
   @IsNotEmptyObject({}, { message: 'Formato inválido' })
   address: CreateAddressDto;

--- a/src/place/dto/place/create-place.dto.ts
+++ b/src/place/dto/place/create-place.dto.ts
@@ -6,6 +6,7 @@ import {
   IsNotEmptyObject,
   IsPhoneNumber,
   IsString,
+  IsUUID,
 } from 'class-validator';
 
 export class CreatePlaceDto {
@@ -33,6 +34,9 @@ export class CreatePlaceDto {
 
   @IsEmail({}, { message: 'Email inválido' })
   email: string;
+
+  @IsUUID('4', { message: 'Formato inválido' })
+  ownerId: string;
 
   @IsNotEmptyObject({}, { message: 'Formato inválido' })
   Address: CreateAddressDto;

--- a/src/place/dto/place/create-place.dto.ts
+++ b/src/place/dto/place/create-place.dto.ts
@@ -1,0 +1,46 @@
+import { CreateAddressDto } from 'src/address/dto/create-address.dto';
+import { CreateWorkTimeDto } from '../work-time/create-work-time.dto';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsNotEmptyObject,
+  IsPhoneNumber,
+  IsString,
+} from 'class-validator';
+
+export class CreatePlaceDto {
+  @IsString({ message: 'Formato inválido' })
+  @IsNotEmpty({ message: 'Campo nome não pode estar vazio' })
+  name: string;
+
+  @IsString({ message: 'Formato inválido' })
+  @IsNotEmpty({ message: 'Campo razão social não pode estar vazio' })
+  businessName: string;
+
+  @IsString({ message: 'Formato inválido' })
+  @IsNotEmpty({ message: 'Campo CNPJ não pode estar vazio' })
+  cnpj: string;
+
+  @IsString({ message: 'Formato inválido' })
+  @IsNotEmpty({ message: 'Campo CPF não pode estar vazio' })
+  cpf: string;
+
+  @IsPhoneNumber('BR', { message: 'Número de telefone inválido' })
+  phone: string;
+
+  @IsPhoneNumber('BR', { message: 'Número de telefone inválido' })
+  secondPhone?: string;
+
+  @IsEmail({}, { message: 'Email inválido' })
+  email: string;
+
+  @IsNotEmptyObject({}, { message: 'Formato inválido' })
+  Address: CreateAddressDto;
+
+  @IsNotEmptyObject({}, { message: 'Formato inválido' })
+  postalBox: CreateAddressDto;
+
+  @IsNotEmptyObject({}, { message: 'Formato inválido' })
+  workTime: CreateWorkTimeDto;
+  // socialMedias: CreateSocialMediasDto;
+}

--- a/src/place/dto/place/create-place.dto.ts
+++ b/src/place/dto/place/create-place.dto.ts
@@ -4,6 +4,7 @@ import {
   IsEmail,
   IsNotEmpty,
   IsNotEmptyObject,
+  IsOptional,
   IsPhoneNumber,
   IsString,
 } from 'class-validator';
@@ -34,8 +35,12 @@ export class CreatePlaceDto {
   @IsEmail({}, { message: 'Email inválido' })
   email: string;
 
-  // @IsUUID('4', { message: 'Formato inválido' })
-  // ownerId: string;
+  @IsOptional()
+  @IsString({ message: 'Formato inválido' })
+  @IsNotEmpty({
+    message: 'Campo código do estabelecimento não pode estar vazio',
+  })
+  code?: string;
 
   @IsNotEmptyObject({}, { message: 'Formato inválido' })
   address: CreateAddressDto;

--- a/src/place/dto/place/create-place.dto.ts
+++ b/src/place/dto/place/create-place.dto.ts
@@ -39,7 +39,7 @@ export class CreatePlaceDto {
   ownerId: string;
 
   @IsNotEmptyObject({}, { message: 'Formato inválido' })
-  Address: CreateAddressDto;
+  address: CreateAddressDto;
 
   @IsNotEmptyObject({}, { message: 'Formato inválido' })
   postalBox: CreateAddressDto;

--- a/src/place/entities/place.entity.ts
+++ b/src/place/entities/place.entity.ts
@@ -35,9 +35,12 @@ export class Place {
   cnpj: string;
 
   @Column()
-  phone: string;
+  cpf: string;
 
   @Column()
+  phone: string;
+
+  @Column({ nullable: true })
   secondPhone: string;
 
   @Column()

--- a/src/place/entities/place.entity.ts
+++ b/src/place/entities/place.entity.ts
@@ -13,6 +13,7 @@ import {
 } from 'typeorm';
 import { WorkTime } from './work-time.entity';
 import { SocialMedias } from './social-medias.entity';
+import { User } from 'src/user/entities/user.entity';
 
 @Entity()
 export class Place {
@@ -45,6 +46,10 @@ export class Place {
 
   @Column()
   email: string;
+
+  @ManyToMany(() => User)
+  @JoinTable()
+  owners: User[];
 
   @ManyToOne(() => Address, { onDelete: 'SET NULL' })
   address: Address;

--- a/src/place/entities/place.entity.ts
+++ b/src/place/entities/place.entity.ts
@@ -26,25 +26,25 @@ export class Place {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @Column()
+  @Column({ unique: true })
   name: string;
 
   @Column()
   businessName: string;
 
-  @Column()
+  @Column({ unique: true })
   cnpj: string;
 
-  @Column()
+  @Column({ unique: true })
   cpf: string;
 
-  @Column()
+  @Column({ unique: true })
   phone: string;
 
   @Column({ nullable: true })
   secondPhone: string;
 
-  @Column()
+  @Column({ unique: true })
   email: string;
 
   @ManyToMany(() => User)

--- a/src/place/entities/place.entity.ts
+++ b/src/place/entities/place.entity.ts
@@ -26,6 +26,9 @@ export class Place {
   @UpdateDateColumn()
   updatedAt: Date;
 
+  @Column({ nullable: true })
+  code: string;
+
   @Column({ unique: true })
   name: string;
 

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -1,7 +1,26 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post, Req } from '@nestjs/common';
 import { PlaceService } from './place.service';
+import { AuthenticatedRequest } from 'src/auth/types/authenticated-request.type';
+import { CreatePlaceDto } from './dto/place/create-place.dto';
+import { CreateAddressDto } from 'src/address/dto/create-address.dto';
+import { CreateWorkTimeDto } from './dto/work-time/create-work-time.dto';
 
 @Controller('place')
 export class PlaceController {
   constructor(private readonly placeService: PlaceService) {}
+
+  @Post('me')
+  async created(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: CreatePlaceDto,
+    @Body('address') address: CreateAddressDto,
+    @Body('postalBox') postalBox: CreateAddressDto,
+    @Body('workTime') workTime: CreateWorkTimeDto,
+  ) {
+    const place = await this.placeService.create(
+      { ...dto, address, postalBox, workTime },
+      req.user,
+    );
+    return place;
+  }
 }

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Post, Req } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Req,
+} from '@nestjs/common';
 import { PlaceService } from './place.service';
 import { AuthenticatedRequest } from 'src/auth/types/authenticated-request.type';
 import { CreatePlaceDto } from './dto/place/create-place.dto';
@@ -21,6 +29,12 @@ export class PlaceController {
       { ...dto, address, postalBox, workTime },
       req.user,
     );
+    return place;
+  }
+
+  @Get(':id')
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    const place = await this.placeService.findOneByOrFail({ id });
     return place;
   }
 }

--- a/src/place/place.controller.ts
+++ b/src/place/place.controller.ts
@@ -37,4 +37,13 @@ export class PlaceController {
     const place = await this.placeService.findOneByOrFail({ id });
     return place;
   }
+
+  @Post(':id/work-time')
+  async addWorkTime(
+    @Body() dto: CreateWorkTimeDto,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    const place = await this.placeService.addWorkTime(dto, id);
+    return place;
+  }
 }

--- a/src/place/place.module.ts
+++ b/src/place/place.module.ts
@@ -6,9 +6,13 @@ import { Place } from './entities/place.entity';
 import { WorkTime } from './entities/work-time.entity';
 import { SocialMedias } from './entities/social-medias.entity';
 import { WorkTimeService } from './services/work-time.service';
+import { AddressModule } from 'src/address/address.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Place, WorkTime, SocialMedias])],
+  imports: [
+    TypeOrmModule.forFeature([Place, WorkTime, SocialMedias]),
+    AddressModule,
+  ],
   controllers: [PlaceController],
   providers: [PlaceService, WorkTimeService],
   exports: [PlaceService, WorkTimeService],

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Place } from './entities/place.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -54,8 +54,31 @@ export class PlaceService {
       owners: [owner],
     };
 
-    const created = this.placeRepository.create(place);
-    return created;
+    const created = await this.save(place);
+    return this.findOneByOrFail({ id: created.id });
+  }
+
+  async findOneByOrFail(placeData: Partial<Place>) {
+    const place = await this.findOneBy(placeData);
+
+    if (!place) {
+      throw new NotFoundException('Esse estabelecimento não existe.');
+    }
+
+    return place;
+  }
+
+  async findOneBy(placeData: Partial<Place>) {
+    return this.placeRepository.findOne({
+      where: placeData,
+      relations: {
+        owners: true,
+        address: true,
+        postalBox: true,
+        workTimes: true,
+        socialMedias: true,
+      },
+    });
   }
 
   async save(placeData: Partial<Place>) {

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -41,7 +41,7 @@ export class PlaceService {
     // criar um social medias (ainda não)
     // depois cria-se o objeto
     const place: PlaceType = {
-      code: process.env.DEFAULT_PLACE_CODE,
+      code: dto.code,
       name: dto.name,
       businessName: dto.businessName,
       cnpj,

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -1,4 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { Place } from './entities/place.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 
 @Injectable()
-export class PlaceService {}
+export class PlaceService {
+  constructor(
+    @InjectRepository(Place)
+    private readonly placeRepository: Repository<Place>,
+  ) {}
+}

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -143,7 +143,7 @@ export class PlaceService {
       });
     }
 
-    // return this.workTimeService.remove(id);
+    return this.workTimeService.remove(id);
   }
 
   async save(placeData: Partial<Place>) {

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -3,6 +3,7 @@ import { Place } from './entities/place.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { generateBadRequestException } from 'src/common/generate-exception';
+import { CreatePlaceDto } from './dto/place/create-place.dto';
 
 @Injectable()
 export class PlaceService {
@@ -12,6 +13,15 @@ export class PlaceService {
     @InjectRepository(Place)
     private readonly placeRepository: Repository<Place>,
   ) {}
+
+  create(dto: CreatePlaceDto) {
+    // validar documentos
+    // criar endereço
+    // criar caixa postal
+    // criar um work time
+    // criar um social medias (ainda não)
+    // depois cria-se o objeto
+  }
 
   async save(placeData: Partial<Place>) {
     const http400 = generateBadRequestException(

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -41,6 +41,7 @@ export class PlaceService {
     // criar um social medias (ainda não)
     // depois cria-se o objeto
     const place: PlaceType = {
+      code: process.env.DEFAULT_PLACE_CODE,
       name: dto.name,
       businessName: dto.businessName,
       cnpj,

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -122,6 +122,30 @@ export class PlaceService {
     return this.findOneByOrFail({ id });
   }
 
+  async removeWorkTime(id: string) {
+    const workTime = await this.workTimeService.findOneByOrFail({ id });
+
+    if (workTime.isDefault) {
+      throw new BadRequestException(
+        'Não é possível excluir o horário que está como padrão',
+      );
+    }
+
+    if (workTime.places.length > 0) {
+      const { places } = workTime;
+
+      places.forEach(item => {
+        if (item.workTimes.length === 1) {
+          throw new BadRequestException(
+            `${item.businessName} precisa ter ao menos 1 horário`,
+          );
+        }
+      });
+    }
+
+    // return this.workTimeService.remove(id);
+  }
+
   async save(placeData: Partial<Place>) {
     const http400 = generateBadRequestException(
       'Erro ao salvar o estabelecimento',

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { Place } from './entities/place.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -8,6 +13,7 @@ import { AddressService } from 'src/address/address.service';
 import { WorkTimeService } from './services/work-time.service';
 import { User } from 'src/user/entities/user.entity';
 import { PlaceType } from './types/place';
+import { CreateWorkTimeDto } from './dto/work-time/create-work-time.dto';
 
 @Injectable()
 export class PlaceService {
@@ -80,6 +86,40 @@ export class PlaceService {
         socialMedias: true,
       },
     });
+  }
+
+  async addWorkTime(dto: CreateWorkTimeDto, id: string) {
+    if (dto.isDefault === undefined || dto.isDefault === null) {
+      throw new BadRequestException(
+        'Campo horário padrão não pode estar vazio',
+      );
+    }
+
+    const place = await this.findOneByOrFail({ id });
+
+    if (place.workTimes.length >= 5) {
+      throw new BadRequestException(
+        'Só é possível cadastrar 5 horários por estabelecimento',
+      );
+    }
+
+    if (dto.isDefault) {
+      const workTimes = place.workTimes.filter(item => item.isDefault === true);
+
+      if (workTimes.length > 0) {
+        const defaultWorkTime = workTimes[0];
+        await this.workTimeService.save({
+          ...defaultWorkTime,
+          isDefault: false,
+        });
+      }
+    }
+
+    const workTime = await this.workTimeService.findOneOrCreate(dto.shift, dto);
+    place.workTimes.push(workTime);
+    await this.save(place);
+
+    return this.findOneByOrFail({ id });
   }
 
   async save(placeData: Partial<Place>) {

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -4,6 +4,10 @@ import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { generateBadRequestException } from 'src/common/generate-exception';
 import { CreatePlaceDto } from './dto/place/create-place.dto';
+import { AddressService } from 'src/address/address.service';
+import { WorkTimeService } from './services/work-time.service';
+import { User } from 'src/user/entities/user.entity';
+import { PlaceType } from './types/place';
 
 @Injectable()
 export class PlaceService {
@@ -12,15 +16,46 @@ export class PlaceService {
   constructor(
     @InjectRepository(Place)
     private readonly placeRepository: Repository<Place>,
+    private readonly addressService: AddressService,
+    private readonly workTimeService: WorkTimeService,
   ) {}
 
-  create(dto: CreatePlaceDto) {
+  async create(dto: CreatePlaceDto, user: User) {
+    // obter usuário
+    const owner = user;
+
     // validar documentos
+    const cpf = dto.cpf;
+    const cnpj = dto.cnpj;
+
     // criar endereço
+    const address = await this.addressService.create(dto.address);
     // criar caixa postal
+    const postalBox = dto.postalBox
+      ? await this.addressService.create(dto.postalBox)
+      : address;
+
     // criar um work time
+    const workTime = await this.workTimeService.create(dto.workTime);
+
     // criar um social medias (ainda não)
     // depois cria-se o objeto
+    const place: PlaceType = {
+      name: dto.name,
+      businessName: dto.businessName,
+      cnpj,
+      cpf,
+      phone: dto.phone,
+      secondPhone: dto.secondPhone ?? dto.phone,
+      email: dto.email,
+      address,
+      postalBox,
+      workTimes: [workTime],
+      owners: [owner],
+    };
+
+    const created = this.placeRepository.create(place);
+    return created;
   }
 
   async save(placeData: Partial<Place>) {

--- a/src/place/place.service.ts
+++ b/src/place/place.service.ts
@@ -1,12 +1,32 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Place } from './entities/place.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
+import { generateBadRequestException } from 'src/common/generate-exception';
 
 @Injectable()
 export class PlaceService {
+  private readonly logger = new Logger(PlaceService.name);
+
   constructor(
     @InjectRepository(Place)
     private readonly placeRepository: Repository<Place>,
   ) {}
+
+  async save(placeData: Partial<Place>) {
+    const http400 = generateBadRequestException(
+      'Erro ao salvar o estabelecimento',
+    );
+    const created = await this.placeRepository
+      .save(placeData)
+      .catch((err: unknown) => {
+        if (err instanceof Error) {
+          this.logger.error(http400.message, err.stack);
+        }
+
+        throw http400;
+      });
+
+    return created;
+  }
 }

--- a/src/place/services/work-time.service.ts
+++ b/src/place/services/work-time.service.ts
@@ -68,6 +68,9 @@ export class WorkTimeService {
   async findOneBy(workTimeData: Partial<WorkTime>) {
     return this.workTimeRepository.findOne({
       where: workTimeData,
+      relations: {
+        places: { workTimes: true },
+      },
     });
   }
 

--- a/src/place/services/work-time.service.ts
+++ b/src/place/services/work-time.service.ts
@@ -74,6 +74,12 @@ export class WorkTimeService {
     });
   }
 
+  async remove(id: string) {
+    const workTime = await this.findOneByOrFail({ id });
+    await this.workTimeRepository.delete({ id });
+    return workTime;
+  }
+
   async save(workTimeData: Partial<WorkTime>) {
     const http400 = generateBadRequestException(
       'Erro ao salvar o horário de serviço',

--- a/src/place/services/work-time.service.ts
+++ b/src/place/services/work-time.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { WorkTime } from '../entities/work-time.entity';
 import { Repository } from 'typeorm';
@@ -23,6 +23,22 @@ export class WorkTimeService {
     };
 
     return this.save(workTime);
+  }
+
+  async findOneByOrFail(workTimeData: Partial<WorkTime>) {
+    const workTime = await this.findOneBy(workTimeData);
+
+    if (!workTime) {
+      throw new NotFoundException('Esse horário de serviço não existe');
+    }
+
+    return workTime;
+  }
+
+  async findOneBy(workTimeData: Partial<WorkTime>) {
+    return this.workTimeRepository.findOne({
+      where: workTimeData,
+    });
   }
 
   async save(workTimeData: Partial<WorkTime>) {

--- a/src/place/services/work-time.service.ts
+++ b/src/place/services/work-time.service.ts
@@ -1,9 +1,15 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { WorkTime } from '../entities/work-time.entity';
 import { Repository } from 'typeorm';
 import { CreateWorkTimeDto } from '../dto/work-time/create-work-time.dto';
 import { generateBadRequestException } from 'src/common/generate-exception';
+import { Shift } from 'src/common/enums/work-shifts.enum';
 
 @Injectable()
 export class WorkTimeService {
@@ -13,6 +19,30 @@ export class WorkTimeService {
     @InjectRepository(WorkTime)
     private readonly workTimeRepository: Repository<WorkTime>,
   ) {}
+
+  async findOneOrCreate(shift: Shift, dto?: CreateWorkTimeDto) {
+    const workTime = await this.findOneBy({ shift });
+
+    if (dto) {
+      if (shift === Shift.Fifth) {
+        const created = await this.create(dto);
+        return this.findOneByOrFail({ id: created.id });
+      }
+
+      if (!workTime) {
+        const created = await this.create(dto);
+        return this.findOneByOrFail({ id: created.id });
+      }
+    }
+
+    if (!workTime) {
+      throw new BadRequestException(
+        'Horário de serviço não encontrado.\nDados não enviados',
+      );
+    }
+
+    return workTime;
+  }
 
   create(dto: CreateWorkTimeDto) {
     const workTime = {

--- a/src/place/types/place.ts
+++ b/src/place/types/place.ts
@@ -1,0 +1,6 @@
+import { Place } from '../entities/place.entity';
+
+export type PlaceType = Omit<
+  Place,
+  'id' | 'createdAt' | 'updatedAt' | 'socialMedias'
+>;

--- a/src/place/types/place.ts
+++ b/src/place/types/place.ts
@@ -2,5 +2,5 @@ import { Place } from '../entities/place.entity';
 
 export type PlaceType = Omit<
   Place,
-  'id' | 'createdAt' | 'updatedAt' | 'socialMedias'
->;
+  'id' | 'createdAt' | 'updatedAt' | 'socialMedias' | 'code'
+> & { code?: string };

--- a/src/user/data/relations/user.ts
+++ b/src/user/data/relations/user.ts
@@ -1,6 +1,6 @@
 export const relations = {
   roles: true,
   workTime: true,
-  // tips: true,
-  // vouchers: { user: true, createdBy: true },
+  tips: true,
+  vouchers: { user: true, createdBy: true },
 };


### PR DESCRIPTION
Used `Place` entity when `Place.workTimes` is needed and created `ParseWorkDayPipe` to use it.
`User` entity can have a `WorkDay` instance too by workTime field.
`Place.code` is being used to set a default `Place` for the system general start and end time.